### PR TITLE
Fix issue: electron-settings does not populate to watch handler at th…

### DIFF
--- a/lib/settings.js
+++ b/lib/settings.js
@@ -78,6 +78,7 @@ class Settings extends EventEmitter {
   initialize() {
     const rsp = this._readSettings();
     this._cacheObj = rsp.data;
+    this._handleObjectChanged();
     this.emit(Settings.Events.INITIALIZED, rsp);
   }
 

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -78,8 +78,8 @@ class Settings extends EventEmitter {
   initialize() {
     const rsp = this._readSettings();
     this._cacheObj = rsp.data;
-    this._handleObjectChanged();
     this.emit(Settings.Events.INITIALIZED, rsp);
+    this._handleObjectChanged();
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-settings",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "A simple persistent user settings framework for Electron.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Issue: Electron settings does not populate to watch handler at the first time when setting file is loaded
Resolution: populate for all handler after SETTING file is loaded