### PR TITLE
Fix delete incorrectly

### DIFF
--- a/lib/settings.js
+++ b/lib/settings.js
@@ -78,6 +78,7 @@ class Settings extends EventEmitter {
   initialize() {
     const rsp = this._readSettings();
     this._cacheObj = rsp.data;
+    this._handleObjectChanged();
     this.emit(Settings.Events.INITIALIZED, rsp);
   }
 

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -78,7 +78,6 @@ class Settings extends EventEmitter {
   initialize() {
     const rsp = this._readSettings();
     this._cacheObj = rsp.data;
-    this._handleObjectChanged();
     this.emit(Settings.Events.INITIALIZED, rsp);
     this._handleObjectChanged();
   }

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -192,7 +192,7 @@ class Settings extends EventEmitter {
     if (keyPath === '') {
       this._cacheObj = {};
     } else {
-      this._cacheObj = _.unset(this._cacheObj, keyPath);
+      _.unset(this._cacheObj, keyPath);
     }
 
     this._handleObjectChanged(keyPath);


### PR DESCRIPTION
Issue: delete api works incorrect

Root cause: _.unset returns true => cache object is assigned to true 